### PR TITLE
Add support for Typescript compilation as intermediate build step.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.1",
   "description": "Design tokens for Suomifi design system",
   "main": "dist/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "README.md"
@@ -12,27 +11,23 @@
   "repository": "https://github.com/vrk-kpa/suomifi-design-tokens",
   "author": "Joonas Kallunki & Aappo Ålander",
   "license": "MIT",
-  "dependencies": {
-    "commander": "3.0.0",
-    "copyfiles": "2.1.1"
-  },
   "scripts": {
-    "prettier": "prettier --write \"tmp/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
+    "prettier": "prettier --write \"tmp/**/*.scss\"",
     "clean:tmp": "rimraf tmp",
     "clean:dist": "rimraf dist",
-    "build:convert": "node ./src/convert.js --format 'js scss' --outdir ./tmp",
-    "build:rollup": "rollup --config",
-    "build:copyfiles": "copyfiles -f ./src/static/* ./dist/esm/",
-    "build:copytypes": "copyfiles -f ./tmp/*.d.ts ./dist/esm/",
+    "build:convert": "node ./src/convert.js --format 'ts scss' --outdir ./tmp",
+    "build:tsc": "tsc ./tmp/index.ts --declaration --outDir ./dist",
     "build:copyscss": "copyfiles -f ./tmp/*.scss ./dist/",
     "prebuild": "npm-run-all clean:tmp clean:dist build:convert prettier",
-    "build": "npm-run-all build:rollup",
-    "postbuild": "npm-run-all build:copyscss build:copytypes build:copyfiles clean:tmp"
+    "build": "npm build:tsc",
+    "postbuild": "npm-run-all build:copyscss clean:tmp"
   },
   "devDependencies": {
     "npm-run-all": "4.1.5",
     "prettier": "1.18.2",
     "rimraf": "3.0.0",
-    "rollup": "1.20.2"
+    "typescript": "3.6.2",
+    "commander": "3.0.0",
+    "copyfiles": "2.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:tsc": "tsc ./tmp/index.ts --declaration --outDir ./dist",
     "build:copyscss": "copyfiles -f ./tmp/*.scss ./dist/",
     "prebuild": "npm-run-all clean:tmp clean:dist build:convert prettier",
-    "build": "npm build:tsc",
+    "build": "npm-run-all build:tsc",
     "postbuild": "npm-run-all build:copyscss clean:tmp"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,21 +2,6 @@
 # yarn lockfile v1
 
 
-"@types/estree@0.0.39":
-  version "0.0.39"
-  resolved "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
-  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
-
-"@types/node@^12.7.2":
-  version "12.7.2"
-  resolved "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
-  integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
-
-acorn@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz#26b8d1cd9a9b700350b71c0905546f64d1284e7a"
-  integrity sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==
-
 ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
@@ -515,15 +500,6 @@ rimraf@3.0.0:
   dependencies:
     glob "^7.1.3"
 
-rollup@1.20.2:
-  version "1.20.2"
-  resolved "https://registry.npmjs.org/rollup/-/rollup-1.20.2.tgz#0e1be13cb5de244c9c463027092f7c93461558b9"
-  integrity sha512-pF4jFzNWMUuudIAeiTgOcSxn8XkBN2Y2/IwPR7iL/IZ8k9RwoLyp2QwNWiYT+HF537zwpmzZHTBYw345H9vq1A==
-  dependencies:
-    "@types/estree" "0.0.39"
-    "@types/node" "^12.7.2"
-    acorn "^7.0.0"
-
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -638,6 +614,11 @@ through2@^2.0.1:
   dependencies:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
+
+typescript@3.6.2:
+  version "3.6.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
+  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This PR adds support for Typescript compilation as an intermediate build step when creating the tokens interfaces and object instead of generating js and d.ts files directly.

- Convert.js now generates a typescript file instead of js and d.ts files.
- Rollup is replaced by typescript compilation.
- Prettier is only used for scss files after dynamic generation and before moving those to dist directory.