### PR TITLE
[Breaking]: Font family export formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Tokens are available as named SCSS variables and mixins with **\$fi-** prefix. T
 
 ### 🎨 Colors
 
-Color tokens are available as variables with additional **colors-** prefix. Colors are provided as hsl values.
+Color tokens are available as variables with additional **color-** prefix. Colors are provided as hsl values.
 
 Example from **tokens.scss**:
 
@@ -48,15 +48,17 @@ Example use case:
 
 ### 🖋 Typography
 
-Typography tokens are available as mixins with additional **typograhpy-** prefix.
+Typography tokens are available as mixins with additional **text-** prefix.
 
 Example from **tokens.scss**:
 
 ```scss
 @mixin fi-text-heading1 {
-  font-family: 'Source Sans Pro, Helvetica Neue, Arial, sans-serif';
+  font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial',
+    sans-serif;
   font-size: 40px;
   line-height: 48px;
+  font-weight: 300;
 }
 ```
 
@@ -99,8 +101,7 @@ import { tokens } from 'suomifi-design-tokens';
 TypeScript example with typings:
 
 ```ts
-import { tokens } from "suomifi-design-tokens";
-import { DesignTokens }
+import { tokens, DesignTokens } from 'suomifi-design-tokens';
 ```
 
 ### 🎨 Colors
@@ -142,12 +143,8 @@ Example from **tokens object**:
 exports.tokens = {
   typography: {
     heading1: {
-      fontFamily: [
-        'Source Sans Pro',
-        'Helvetica Neue',
-        'Arial',
-        'sans-serif'
-      ],
+      fontFamily:
+        "'Source Sans Pro', 'Helvetica Neue', 'Arial', sans-serif",
       fontSize: { value: 40, unit: 'px' },
       lineHeight: { value: 48, unit: 'px' },
       fontWeight: 300
@@ -162,7 +159,7 @@ JavaScript example:
 const heading1 = tokens.typograhpy.heading1;
 const heading1FontSize =
   heading1.fontSize.value + heading1.fontSize.unit;
-const heading1FontFamily = Array.join(heading1.fontFamily);
+const heading1FontFamily = heading1.fontFamily;
 ```
 
 TypeScript example with typings:
@@ -173,7 +170,7 @@ import { TypographyToken } from 'suomifi-desing-tokens';
 const heading1: TypographyToken = tokens.typography.heading1;
 const heading1FontSize: string =
   heading1.fontSize.value + heading1.fontSize.unit;
-const heading1FontFamily: string = Array.join(heading1.fontFamily);
+const heading1FontFamily: string = heading1.fontFamily;
 ```
 
 ### 📏 Spacing

--- a/src/convert.js
+++ b/src/convert.js
@@ -101,7 +101,9 @@ function formatTypographyToScss(tokens, scssPrefix) {
     return `@mixin ${scssPrefix}-${token.prefix}-${convertCamelCaseToKebabCase(
       token.name,
     )} {
-      font-family: "${token.value.fontFamily.join(', ')}";
+      font-family: '${token.value.fontFamily.join("', '")}', ${
+      token.value.genericFontFamily
+    };
       font-size: ${token.value.fontSize.value}${
       token.value.fontSize.unit !== null ? token.value.fontSize.unit : ''
     };
@@ -184,7 +186,14 @@ function formatTypographyToTS(tokens) {
     {},
     ...tokens.map(token => {
       return {
-        [token.name]: token.value,
+        [token.name]: {
+          fontFamily: `${token.value.fontFamily
+            .map(font => `'${font}', `)
+            .join('')}${token.value.genericFontFamily}`,
+          fontSize: token.value.fontSize,
+          lineHeight: token.value.lineHeight,
+          fontWeight: token.value.fontWeight,
+        },
       };
     }),
   );

--- a/src/convert.js
+++ b/src/convert.js
@@ -110,6 +110,7 @@ function formatTypographyToScss(tokens, scssPrefix) {
       line-height: ${token.value.lineHeight.value}${
       token.value.lineHeight.unit !== null ? token.value.lineHeight.unit : ''
     };
+      font-weight: ${token.value.fontWeight};
     }`;
   });
 }

--- a/src/interfaces.ts.template
+++ b/src/interfaces.ts.template
@@ -12,7 +12,7 @@ export interface ColorToken {
 }
 
 export interface TypographyToken {
-  fontFamily: Array<string>;
+  fontFamily: string;
   fontSize: ValueUnit;
   lineHeight: ValueUnit;
   fontWeight: number;

--- a/src/tokens.json
+++ b/src/tokens.json
@@ -328,12 +328,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 18,
           "unit": "px"
@@ -351,12 +347,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
           "unit": "px"
@@ -374,12 +366,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
           "unit": "px"
@@ -397,12 +385,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
           "unit": "px"
@@ -420,12 +404,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
           "unit": "px"
@@ -443,12 +423,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
           "unit": "px"
@@ -466,12 +442,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 22,
           "unit": "px"
@@ -489,12 +461,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 20,
           "unit": "px"
@@ -512,12 +480,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 40,
           "unit": "px"
@@ -535,12 +499,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 32,
           "unit": "px"
@@ -558,12 +518,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 40,
           "unit": "px"
@@ -581,12 +537,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 32,
           "unit": "px"
@@ -604,12 +556,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 28,
           "unit": "px"
@@ -627,12 +575,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 26,
           "unit": "px"
@@ -650,12 +594,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 22,
           "unit": "px"
@@ -673,12 +613,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 20,
           "unit": "px"
@@ -696,12 +632,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 18,
           "unit": "px"
@@ -719,12 +651,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
           "unit": "px"
@@ -742,12 +670,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
           "unit": "px"
@@ -765,12 +689,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
           "unit": "px"
@@ -788,12 +708,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
           "unit": "px"
@@ -811,12 +727,8 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans Pro",
-          "Helvetica Neue",
-          "Arial",
-          "sans-serif"
-        ],
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
           "unit": "px"


### PR DESCRIPTION
## Description

Fixes for Font family exports
- JS export for typography tokens font family is now of type string with a fallback **(Breaking change, used to be an array of strings)**
- SCSS export for typography tokens font family is now an array of strings with following fallback
- For safety, all font families are now correctly quoted
- Font family fallbacks are unquoted
- Tokens JSON now explicitly defines a genericFontFamily as a fallback

Fix for Font weight SCSS export
- Added font weight for scss typography tokens

Fixes and improvements for Readme

closes #9 #10 

## Motivation and Context

Font family exports were incorrectly quoted and didn't work as expected. The exports now follow specs better: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family

## How Has This Been Tested?

Using `yarn validate` and with Create React App dummy project using TypeScript (with both, Styled Components and SCSS).

