### PR TITLE
Release 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-design-tokens",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Design tokens for Suomifi design system",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-design-tokens",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Design tokens for Suomifi design system",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Typography tokens font family is now string with a fallback (used to be an array of strings)
- SCSS export for typography tokens font family is now an array of strings with following fallback
- For safety, all font families are now correctly quoted
- Font family fallbacks are unquoted
- Tokens JSON now explicitly defines a genericFontFamily as a fallback
- Fix for Font weight SCSS export
- Added font weight for scss typography tokens

#11