### PR TITLE
[Feature] Add body text semi-bold variants

### DIFF
--- a/src/tokens.json
+++ b/src/tokens.json
@@ -343,6 +343,25 @@
       "type": "font",
       "comments": []
     },
+    "bodySemiBold": {
+      "category": "typography",
+      "version": "1.0",
+      "value": {
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
+        "fontSize": {
+          "value": 18,
+          "unit": "px"
+        },
+        "lineHeight": {
+          "value": 1.5,
+          "unit": null
+        },
+        "fontWeight": 600
+      },
+      "type": "font",
+      "comments": []
+    },
     "actionElementInnerText": {
       "category": "typography",
       "version": "1.0",
@@ -434,6 +453,25 @@
           "unit": null
         },
         "fontWeight": 400
+      },
+      "type": "font",
+      "comments": []
+    },
+    "bodySemiBoldSmall": {
+      "category": "typography",
+      "version": "1.0",
+      "value": {
+        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "genericFontFamily": "sans-serif",
+        "fontSize": {
+          "value": 16,
+          "unit": "px"
+        },
+        "lineHeight": {
+          "value": 1.5,
+          "unit": null
+        },
+        "fontWeight": 600
       },
       "type": "font",
       "comments": []


### PR DESCRIPTION
## Description
Semi-bold variants for body text and body text small added.

## Related Issue

Closes #14 

## How Has This Been Tested?

Tested locally by building the tokens.