### PR TITLE
[BreakingChange] Tokens export with one export for typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Tokens are available as named SCSS variables and mixins with **\$fi-** prefix. T
 
 Color tokens are available as variables with additional **color-** prefix. Colors are provided as hsl values.
 
-Example from **tokens.scss**:
+Excerpt from **tokens.scss**:
 
 ```scss
 $fi-color-brand-base: hsl(214, 100%, 24%);
@@ -50,7 +50,7 @@ Example use case:
 
 Typography tokens are available as mixins with additional **text-** prefix.
 
-Example from **tokens.scss**:
+Excerpt from **tokens.scss**:
 
 ```scss
 @mixin fi-text-heading1 {
@@ -74,7 +74,7 @@ h1 {
 
 Spacing tokens are available as variables with additional **spacing-** prefix.
 
-Example from **tokens.scss**:
+Excerpt from **tokens.scss**:
 
 ```scss
 $fi-spacing-l: 32px;
@@ -90,64 +90,41 @@ Example use case:
 
 ## JavaScript and TypeScript
 
-Tokens are available as named **tokens** export and can be imported to JavaScript and TypeScript files.
+Tokens are available as named **suomifiDesignTokens** export and can be imported to JavaScript and TypeScript files.
+
+**suomifiDesignTokens** exports the design tokens as css formatted strings and in more granular format so that individual properties are available with values and units.
 
 JavaScript example:
 
 ```js
-import { tokens } from 'suomifi-design-tokens';
+import { suomifiDesignTokens } from 'suomifi-design-tokens';
 ```
 
 TypeScript example with typings:
 
 ```ts
-import { tokens, DesignTokens } from 'suomifi-design-tokens';
+import {
+  suomifiDesignTokens,
+  DesignTokens
+} from 'suomifi-design-tokens';
+
+const tokens: DesignTokens = suomifiDesignTokens;
 ```
 
 ### 🎨 Colors
 
-Color tokens are available with **colors** property. Colors are provided as both separated h, s and l values and as combined hsl string.
+Color tokens are available with **colors** property as css strings. Separated h, s and l values can be accessed through **values** property.
 
-Example from **tokens object**:
+Excerpt from **suomifiDesignTokens** object:
 
 ```js
-exports.tokens = {
+exports.suomifiDesignTokens = {
   colors: {
-    whiteBase: { hsl: 'hsl(0, 0%, 100%)', h: 0, s: 0, l: 100 }
-  }
-};
-```
-
-JavaScript example:
-
-```js
-const brandBaseHsl = tokens.colors.brandBase.hsl;
-```
-
-TypeScript example with typings:
-
-```ts
-import { ColorToken } from 'suomifi-design-tokens';
-
-const brandBase: ColorToken = tokens.colors.brandBase;
-const brandBaseHsl: string = brandBase.hsl;
-```
-
-### 🖋 Typography
-
-Typography tokens are available with **typography** property. Typography is provided with fontFamily, fontSize, lineHeight and fontWeight.
-
-Example from **tokens object**:
-
-```js
-exports.tokens = {
-  typography: {
-    heading1: {
-      fontFamily:
-        "'Source Sans Pro', 'Helvetica Neue', 'Arial', sans-serif",
-      fontSize: { value: 40, unit: 'px' },
-      lineHeight: { value: 48, unit: 'px' },
-      fontWeight: 300
+    whiteBase: 'hsl(0, 0%, 100%)'
+  },
+  values: {
+    colors: {
+      whiteBase: { h: 0, s: 0, l: 100 }
     }
   }
 };
@@ -156,33 +133,46 @@ exports.tokens = {
 JavaScript example:
 
 ```js
-const heading1 = tokens.typography.heading1;
-const heading1FontSize =
-  heading1.fontSize.value + heading1.fontSize.unit;
-const heading1FontFamily = heading1.fontFamily;
+const brandBaseLightness =
+  suomifiDesignTokens.values.colors.brandBase.l;
+
+const brandBaseCss = suomifiDesignTokens.colors.brandBase;
 ```
 
 TypeScript example with typings:
 
 ```ts
-import { TypographyToken } from 'suomifi-design-tokens';
+import { ColorToken } from 'suomifi-design-tokens';
 
-const heading1: TypographyToken = tokens.typography.heading1;
-const heading1FontSize: string =
-  heading1.fontSize.value + heading1.fontSize.unit;
-const heading1FontFamily: string = heading1.fontFamily;
+const brandBase: ColorToken =
+  suomifiDesignTokens.values.colors.brandBase;
+const brandBaseLightness: string = brandBase.l;
+
+const brandBaseCSS: string = suomifiDesignTokens.colors.brandBase;
 ```
 
-### 📏 Spacing
+### 🖋 Typography
 
-Spacing tokens are available with **spacing** property. Spacings are provided with numerical value and format string.
+Typography tokens are available with **typography** property as css strings. Separated fontFamily, fontSize, lineHeight and fontWeight properties can be accessed through **values** property.
 
-Example from **tokens object**:
+Excerpt from **suomifiDesignTokens** object:
 
 ```js
-exports.tokens = {
-  spacing: {
-    l: { value: 32, unit: 'px' }
+exports.suomifiDesignTokens = {
+  typography: {
+    heading1:
+      "font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', sans-serif; font-size: 40px; line-height: 48px; font-weight: 300;"
+  },
+  values: {
+    typography: {
+      heading1: {
+        fontFamily:
+          "'Source Sans Pro', 'Helvetica Neue', 'Arial', sans-serif",
+        fontSize: { value: 40, unit: 'px' },
+        lineHeight: { value: 48, unit: 'px' },
+        fontWeight: 300
+      }
+    }
   }
 };
 ```
@@ -190,8 +180,54 @@ exports.tokens = {
 JavaScript example:
 
 ```js
-const spacingL = tokens.spacing.l;
+const heading1 = suomifiDesignTokens.values.typography.heading1;
+const heading1FontSize =
+  heading1.fontSize.value + heading1.fontSize.unit;
+const heading1FontFamily = heading1.fontFamily;
+
+const heading1Css = suomifiDesignTokens.typography.heading1;
+```
+
+TypeScript example with typings:
+
+```ts
+import { TypographyToken } from 'suomifi-design-tokens';
+
+const heading1: TypographyToken =
+  suomifiDesignTokens.values.typography.heading1;
+const heading1FontSize: string =
+  heading1.fontSize.value + heading1.fontSize.unit;
+const heading1FontFamily: string = heading1.fontFamily;
+
+const heading1Css: string = suomifiDesignTokens.typography.heading1;
+```
+
+### 📏 Spacing
+
+Spacing tokens are available with **spacing** property as CSS strings. Separated unit and value properties can be accessed through **values** property.
+
+Excerpt from **suomifiDesignTokens** object:
+
+```js
+exports.suomifiDesignTokens = {
+  spacing: {
+    l: '32px'
+  },
+  values: {
+    spacing: {
+      l: { value: 32, unit: 'px' }
+    }
+  }
+};
+```
+
+JavaScript example:
+
+```js
+const spacingL = suomifiDesignTokens.values.spacing.l;
 const spacingLWithUnit = spacingL.value + spacingL.unit;
+
+const spacingLCss = suomifiDesignTokens.spacing.l;
 ```
 
 TypeScript example with typings:
@@ -199,8 +235,10 @@ TypeScript example with typings:
 ```ts
 import { ValueUnit } from 'suomifi-design-tokens';
 
-const spacingL: ValueUnit = tokens.spacing.l;
+const spacingL: ValueUnit = suomifiDesignTokens.values.spacing.l;
 const spacingLWithUnit: string = spacingL.value + spacingL.unit;
+
+const spacingLCss: string = suomifiDesignTokens.spacing.l;
 ```
 
 ## ⌨️ Development

--- a/src/converters/index.js
+++ b/src/converters/index.js
@@ -1,5 +1,5 @@
 module.exports.ts = {
-  converters: [require('./typescript-raw'), require('./typescript-css-in-js')],
+  converters: [require('./typescript')],
   name: 'TypeScript',
   outFileName: 'index',
 };

--- a/src/converters/typescript-css-in-js/interfaces.ts.template
+++ b/src/converters/typescript-css-in-js/interfaces.ts.template
@@ -1,5 +1,0 @@
-export interface DesignTokens {
-  colors: ColorDesignTokens;
-  typography: TypographyDesignTokens;
-  spacing: SpacingDesignTokens;
-}

--- a/src/converters/typescript/index.js
+++ b/src/converters/typescript/index.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const tokensInterfaceName = 'DesignTokens'; // interface name matching the template
+const rawTokensInterfaceName = 'RawDesignTokens'; // interface name for object format tokens matching the template
+const exportObjectName = 'suomifiDesignTokenObjects';
+require.extensions['.template'] = function(module, filename) {
+  module.exports = fs.readFileSync(filename, 'utf8');
+};
+const staticInterfaces = require('./interfaces.ts.template');
+
+const formatToTS = require('./string-format');
+const formatToTSRaw = require('./raw-format');
+
+function convertTokensToTS(tokensByCategory) {
+  return (
+    staticInterfaces +
+    '\n\n' +
+    formatToTSRaw(tokensByCategory, rawTokensInterfaceName, exportObjectName) +
+    formatToTS(tokensByCategory, tokensInterfaceName, exportObjectName) +
+    '\n\n'
+  );
+}
+
+module.exports.format = 'ts';
+module.exports.convert = convertTokensToTS;

--- a/src/converters/typescript/interfaces.ts.template
+++ b/src/converters/typescript/interfaces.ts.template
@@ -1,17 +1,24 @@
+export interface DesignTokens {
+  colors: ColorDesignTokens;
+  typography: TypographyDesignTokens;
+  spacing: SpacingDesignTokens;
+  values: RawDesignTokens
+}
+
 export interface RawDesignTokens {
   colors: RawColorDesignTokens;
   typography: RawTypographyDesignTokens;
   spacing: RawSpacingDesignTokens;
 }
 
-export interface RawColorToken {
+export interface ColorToken {
   hsl: string;
   h: number;
   s: number;
   l: number;
 }
 
-export interface RawTypographyToken {
+export interface TypographyToken {
   fontFamily: string;
   fontSize: ValueUnit;
   lineHeight: ValueUnit;

--- a/src/converters/typescript/raw-format.js
+++ b/src/converters/typescript/raw-format.js
@@ -1,19 +1,20 @@
-const fs = require('fs');
-const rawTokensInterfaceName = 'RawDesignTokens'; // interface name for object format tokens matching the template
-require.extensions['.template'] = function(module, filename) {
-  module.exports = fs.readFileSync(filename, 'utf8');
-};
-const staticInterfaces = require('./interfaces.ts.template');
-
-function convertTokensToTS(tokensByCategory) {
+module.exports = function convertTokensToTS(
+  tokensByCategory,
+  tokensInterfaceName,
+  exportObjectName,
+) {
   return (
-    formatToRawTS(tokensByCategory, rawTokensInterfaceName) +
+    formatToRawTS(tokensByCategory, tokensInterfaceName, exportObjectName) +
     '\n\n' +
-    generateTSInterfaces(tokensByCategory, staticInterfaces)
+    generateTSInterfaces(tokensByCategory)
   );
-}
+};
 
-function formatToRawTS(tokensByCategory, tokensInterfaceName) {
+function formatToRawTS(
+  tokensByCategory,
+  tokensInterfaceName,
+  exportObjectName,
+) {
   const tSExport = Object.assign(
     {},
     ...tokensByCategory.reduce((resultArray, category) => {
@@ -35,7 +36,7 @@ function formatToRawTS(tokensByCategory, tokensInterfaceName) {
       return resultArray;
     }, []),
   );
-  return `export const rawSuomifiDesignTokens: ${tokensInterfaceName} = ${JSON.stringify(
+  return `const ${exportObjectName}: ${tokensInterfaceName} = ${JSON.stringify(
     tSExport,
   )}`;
 }
@@ -101,7 +102,7 @@ function formatColorsToTS(tokens) {
   );
 }
 
-function generateTSInterfaces(tokensByCategory, staticInterfaces) {
+function generateTSInterfaces(tokensByCategory) {
   const interfaceExport = Object.entries(tokensByCategory).reduce(
     (resultArray, [key, value]) => {
       switch (value.category) {
@@ -110,7 +111,7 @@ function generateTSInterfaces(tokensByCategory, staticInterfaces) {
             ...generateTSInterfaceCategory(
               value.tokens,
               'RawColorDesignTokens',
-              'RawColorToken',
+              'ColorToken',
             ),
           );
           return resultArray;
@@ -120,7 +121,7 @@ function generateTSInterfaces(tokensByCategory, staticInterfaces) {
             ...generateTSInterfaceCategory(
               value.tokens,
               'RawTypographyDesignTokens',
-              'RawTypographyToken',
+              'TypographyToken',
             ),
           );
           return resultArray;
@@ -143,7 +144,7 @@ function generateTSInterfaces(tokensByCategory, staticInterfaces) {
     },
     [],
   );
-  return staticInterfaces + interfaceExport.join('');
+  return interfaceExport.join('');
 }
 
 function generateTSInterfaceCategory(
@@ -163,6 +164,3 @@ function generateTSInterfaceProperties(tokens, interfaceName) {
     return `${token.name}: ${interfaceName};`;
   });
 }
-
-module.exports.format = 'ts';
-module.exports.convert = convertTokensToTS;

--- a/src/converters/typescript/string-format.js
+++ b/src/converters/typescript/string-format.js
@@ -1,19 +1,16 @@
-const fs = require('fs');
-const tokensInterfaceName = 'DesignTokens'; // interface name matching the template
-require.extensions['.template'] = function(module, filename) {
-  module.exports = fs.readFileSync(filename, 'utf8');
-};
-const staticInterfaces = require('./interfaces.ts.template');
-
-function convertTokensToCssInJS(tokensByCategory) {
+module.exports = function convertTokensToTS(
+  tokensByCategory,
+  tokensInterfaceName,
+  exportObjectName,
+) {
   return (
-    formatToTS(tokensByCategory, tokensInterfaceName) +
+    formatToTS(tokensByCategory, tokensInterfaceName, exportObjectName) +
     '\n\n' +
-    generateTSInterfaces(tokensByCategory, staticInterfaces)
+    generateTSInterfaces(tokensByCategory)
   );
-}
+};
 
-function formatToTS(tokensByCategory, tokensInterfaceName) {
+function formatToTS(tokensByCategory, tokensInterfaceName, exportObjectName) {
   const tSExport = Object.assign(
     {},
     ...tokensByCategory.reduce((resultArray, category) => {
@@ -41,7 +38,8 @@ function formatToTS(tokensByCategory, tokensInterfaceName) {
   );
   return `export const suomifiDesignTokens: ${tokensInterfaceName} = ${JSON.stringify(
     tSExport,
-  )}`;
+  ).slice(0, -1)},
+    values: ${exportObjectName}}`;
 }
 
 function formatValueUnitTokensToString(tokens) {
@@ -71,13 +69,13 @@ function formatTypographyToString(tokens) {
       const lineHeight = `${token.value.lineHeight.value +
         (!!token.value.lineHeight.unit ? token.value.lineHeight.unit : '')}`;
       return {
-        [token.name]: `font-family: ${fontFamily}; font-size: ${fontSize}; line-height: ${lineHeight}; fontWeight: ${token.value.fontWeight};`,
+        [token.name]: `font-family: ${fontFamily}; font-size: ${fontSize}; line-height: ${lineHeight}; font-weight: ${token.value.fontWeight};`,
       };
     }),
   );
 }
 
-function generateTSInterfaces(tokensByCategory, staticInterfaces) {
+function generateTSInterfaces(tokensByCategory) {
   const interfaceExport = Object.entries(tokensByCategory).reduce(
     (resultArray, [key, value]) => {
       switch (value.category) {
@@ -116,7 +114,7 @@ function generateTSInterfaces(tokensByCategory, staticInterfaces) {
     },
     [],
   );
-  return staticInterfaces + interfaceExport.join('');
+  return interfaceExport.join('');
 }
 
 function generateTSStringInterfaceCatergory(tokens, categoryInterfaceName) {
@@ -126,6 +124,3 @@ function generateTSStringInterfaceCatergory(tokens, categoryInterfaceName) {
     '}',
   ];
 }
-
-module.exports.format = 'ts';
-module.exports.convert = convertTokensToCssInJS;


### PR DESCRIPTION
## Description
- Raw design tokens are now exported as part of css-formatted tokes for JS/TS formats.
- Readme updated to reflect latest changes
- fontWeight fixed to font-weight for css string format for JS/TS
- convert is now refactored and split into multiple modules. Parsers and converters are now in separate modules.

## How has this been tested
Tested with empty create react app project using both TS and SCSS formats.