### PR TITLE
Raise version number to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-design-tokens",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Design tokens for Suomifi design system",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Raise version number to 0.6.0 for release. For approval release notes and npm publish needs to be done as well.