### PR TITLE
Change token names to more generic ones according to new design

### DIFF
--- a/src/tokens.json
+++ b/src/tokens.json
@@ -24,7 +24,7 @@
       "desc": "",
       "comments": []
     },
-    "blackLighten42": {
+    "blackLight1": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -48,7 +48,7 @@
       "desc": "",
       "comments": []
     },
-    "depthDark27": {
+    "depthLight4": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -72,7 +72,7 @@
       "desc": "",
       "comments": []
     },
-    "depthLight30": {
+    "depthLight3": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -84,7 +84,7 @@
       "desc": "",
       "comments": []
     },
-    "depthLight26": {
+    "depthLight2": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -96,7 +96,7 @@
       "desc": "",
       "comments": []
     },
-    "depthLight13": {
+    "depthLight1": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -108,7 +108,7 @@
       "desc": "",
       "comments": []
     },
-    "depthSecondaryDark6": {
+    "depthSecondaryDark1": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -132,7 +132,7 @@
       "desc": "",
       "comments": []
     },
-    "highlightDark9": {
+    "highlightDark1": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -156,7 +156,7 @@
       "desc": "",
       "comments": []
     },
-    "highlightLight4": {
+    "highlightLight1": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -168,7 +168,7 @@
       "desc": "",
       "comments": []
     },
-    "highlightLight45": {
+    "highlightLight2": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -180,7 +180,7 @@
       "desc": "",
       "comments": []
     },
-    "highlightLight50": {
+    "highlightLight3": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -192,7 +192,7 @@
       "desc": "",
       "comments": []
     },
-    "highlightLight53": {
+    "highlightLight4": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -228,7 +228,7 @@
       "desc": "",
       "comments": []
     },
-    "accentSecondaryLight40": {
+    "accentSecondaryLight1": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -240,7 +240,7 @@
       "desc": "",
       "comments": []
     },
-    "accentTertiaryDark9": {
+    "accentTertiaryDark1": {
       "category": "colors",
       "version": "1.0",
       "value": {
@@ -312,7 +312,7 @@
       "desc": "",
       "comments": []
     },
-    "alertLight47": {
+    "alertLight1": {
       "category": "colors",
       "version": "1.0",
       "value": {


### PR DESCRIPTION
Changed some of the color token names to more generic ones to allow easier adjustments without creating a disparity between names and values.

Tested by building and checking that the new names appear in the build.