### PR TITLE
[Bugfix]Rename depthLight4 to depthDark1

### DIFF
--- a/src/tokens.json
+++ b/src/tokens.json
@@ -48,7 +48,7 @@
       "desc": "",
       "comments": []
     },
-    "depthLight4": {
+    "depthDark1": {
       "category": "colors",
       "version": "1.0",
       "value": {


### PR DESCRIPTION
Due to erroneous naming in documentation depthDark1 got a wrong name in the last release. This PR fixes that.