### PR TITLE
[Fix] Inset token changed from insetXss to insetXxs

### DIFF
--- a/src/tokens.json
+++ b/src/tokens.json
@@ -832,7 +832,7 @@
       "type": "size",
       "comments": []
     },
-    "insetXss": {
+    "insetXxs": {
       "category": "spacing",
       "version": "1.0",
       "value": {


### PR DESCRIPTION
## Description

Fixing the naming of inset token, from`insetXss` to `insetXxs`

## Motivation

Fixing the naming now as it will be breaking change whenever it will be made. And to prevent confusion when using this tokens-library.

## Release notes

🚨**Breaking change**
- Inset token `insetXss` renamed to `insetXxs`