### PR TITLE
[Feature] Adjust and add color tokens as per new designs

### DIFF
--- a/src/tokens.json
+++ b/src/tokens.json
@@ -60,6 +60,30 @@
       "desc": "",
       "comments": []
     },
+    "depthDark2": {
+      "category": "colors",
+      "version": "1.0",
+      "value": {
+        "h": 201,
+        "s": 7,
+        "l": 46
+      },
+      "type": "hsl",
+      "desc": "",
+      "comments": []
+    },
+    "depthDark3": {
+      "category": "colors",
+      "version": "1.0",
+      "value": {
+        "h": 201,
+        "s": 7,
+        "l": 58
+      },
+      "type": "hsl",
+      "desc": "",
+      "comments": []
+    },
     "depthBase": {
       "category": "colors",
       "version": "1.0",
@@ -222,7 +246,7 @@
       "value": {
         "h": 196,
         "s": 77,
-        "l": 55
+        "l": 44
       },
       "type": "hsl",
       "desc": "",
@@ -234,7 +258,7 @@
       "value": {
         "h": 196,
         "s": 77,
-        "l": 95
+        "l": 97
       },
       "type": "hsl",
       "desc": "",
@@ -270,7 +294,7 @@
       "value": {
         "h": 166,
         "s": 90,
-        "l": 36
+        "l": 34
       },
       "type": "hsl",
       "desc": "",
@@ -316,9 +340,9 @@
       "category": "colors",
       "version": "1.0",
       "value": {
-        "h": 3,
+        "h": 0,
         "s": 59,
-        "l": 95
+        "l": 96
       },
       "type": "hsl",
       "desc": "",


### PR DESCRIPTION
Some color token adjustments were made in design to improve the contrast in some places and add necessary shades for example for form component borders and placeholder texts.

This PR adjusts and adds color tokens as per the new designs shown below:
![värimuutokset](https://user-images.githubusercontent.com/54316341/98091460-2501db00-1e8e-11eb-8040-bd6c79a89b95.png)

As discussed, let's raise the version number in a separate PR.
