### PR TITLE
[Release] Raise version to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-design-tokens",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Design tokens for Suomifi design system",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR raises the version number to 3.1.1 due to recent changes in dependencies. Related tag is also created.

Changes in this version:
* Internal dependency `copyfiles` updated to latest due to a vulnerability in the earlier version.