### PR TITLE
[Release] 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-design-tokens",
-  "version": "3.2.0",
+  "version": "4.2.0",
   "description": "Design tokens for Suomifi design system",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR raises the version number to 4.2.0 in anticipation of release. 

The major version raise is due to a change in a token value.

## Release notes
* Change `accentBase` token value from `hsl(23, 82%, 53%)` to `hsl(23, 82%, 51%)`