### PR TITLE
[Hotfix] highlightBaseToHighlightDark1 gradient direction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-design-tokens",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Design tokens for Suomifi design system",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/derived-tokens.json
+++ b/src/derived-tokens.json
@@ -4,7 +4,7 @@
       "category": "gradients",
       "version": "1.0",
       "value": {
-        "value": "linear-gradient(0deg, {colors.highlightBase} 0%, {colors.highlightDark1} 100%)"
+        "value": "linear-gradient(0deg, {colors.highlightDark1} 0%, {colors.highlightBase} 100%)"
       },
       "type": "derived-string",
       "comments": []


### PR DESCRIPTION
This PR fixes derived token `highlightBaseToHighlightDark1`. The direction of the gradient was incorrect.

Package version number is also increased to 4.1.1. in this PR in anticipation of a new release. 

## Release notes
### Gradient highlightBaseToHighlightDark1
* Fix direction of gradient