### PR TITLE
[Hotfix] Adjust absoluteFocus z-index value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-design-tokens",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Design tokens for Suomifi design system",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/derived-tokens.json
+++ b/src/derived-tokens.json
@@ -163,7 +163,7 @@
         "border": "0px solid {colors.whiteBase}",
         "boxSizing": "border-box",
         "boxShadow": "0 0 0 2px {colors.accentSecondary}",
-        "zIndex": "888"
+        "zIndex": "9999"
       },
       "type": "derived-object",
       "comments": []


### PR DESCRIPTION
This PR changes the derived token `absoluteFocus` slightly. In its previous implementation (in suomifi-ui-components) its z-index value was 9999, but here the z-index was mistakenly set as 888. This PR sets it "back" to 9999. 

Also increased package version number in anticipation of a new release. 

## Release notes
### absoluteFocus
* Change z-index value from 888 to 9999 