### PR TITLE
[Feature] Add accentTertiaryLight1 color token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-design-tokens",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Design tokens for Suomifi design system",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/tokens.json
+++ b/src/tokens.json
@@ -288,6 +288,18 @@
       "desc": "",
       "comments": []
     },
+    "accentTertiaryLight1": {
+      "category": "colors",
+      "version": "1.0",
+      "value": {
+        "h": 284,
+        "s": 36,
+        "l": 94
+      },
+      "type": "hsl",
+      "desc": "",
+      "comments": []
+    },
     "successDark1": {
       "category": "colors",
       "version": "1.0",


### PR DESCRIPTION
This PR adds the `accentTertiaryLight1` color token and increases version number to 4.2.0

![image](https://user-images.githubusercontent.com/17459942/201947491-5c9b1006-c82b-4b1a-8a05-11adbf062476.png)
