### PR TITLE
[Release] Add new info-colors and adjust a few other colors - 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-design-tokens",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Design tokens for Suomifi design system",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/tokens.json
+++ b/src/tokens.json
@@ -30,7 +30,7 @@
       "value": {
         "h": 0,
         "s": 0,
-        "l": 58
+        "l": 42
       },
       "type": "hsl",
       "desc": "",
@@ -234,7 +234,7 @@
       "value": {
         "h": 23,
         "s": 82,
-        "l": 51
+        "l": 50
       },
       "type": "hsl",
       "desc": "",
@@ -293,7 +293,7 @@
       "version": "1.0",
       "value": {
         "h": 284,
-        "s": 36,
+        "s": 35,
         "l": 94
       },
       "type": "hsl",
@@ -341,8 +341,8 @@
       "version": "1.0",
       "value": {
         "h": 42,
-        "s": 100,
-        "l": 49
+        "s": 93,
+        "l": 50
       },
       "type": "hsl",
       "desc": "",
@@ -366,7 +366,7 @@
       "value": {
         "h": 3,
         "s": 59,
-        "l": 48
+        "l": 43
       },
       "type": "hsl",
       "desc": "",
@@ -378,6 +378,30 @@
       "value": {
         "h": 0,
         "s": 59,
+        "l": 96
+      },
+      "type": "hsl",
+      "desc": "",
+      "comments": []
+    },
+    "infoBase": {
+      "category": "colors",
+      "version": "2.0",
+      "value": {
+        "h": 215,
+        "s": 86,
+        "l": 51
+      },
+      "type": "hsl",
+      "desc": "",
+      "comments": []
+    },
+    "infoLight1": {
+      "category": "colors",
+      "version": "2.0",
+      "value": {
+        "h": 216,
+        "s": 100,
         "l": 96
       },
       "type": "hsl",


### PR DESCRIPTION
PR contains additions and changes to color tokens based on new designs in Figma. These changes have been tested locally by using the new colors in suomifi-ui-components through Verdaccio.

Also raised version to 6.0.0 in anticipation of a new release

## Release notes

### Changes and additions to color tokens

#### Changed colors:
- alertBase
   - #AE332D
   - hsla(3, 59%, 43%, 1)
- warningBase
   - #F6AF09
   - hsla(42, 93%, 50%, 1)
- blackLight1
   - #6B6B6B
   - hsla(0, 0%, 42%, 1)
- accentBase
   - #E86717
   - hsla(23, 82%, 50%, 1)
- accentTertiaryLight1
   - #F2EAF5
   - hsla(284, 35%, 94%, 1)

#### New colors:
- infoBase
   - #1770EE
   - hsla(215, 86%, 51%, 1)
- infoLight1
   - #EBF3FF
   - hsla(216, 100%, 96%, 1)
