### PR TITLE
[Fix] CircleCI to use https instead of SSH

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ executors:
 commands:
   checkout_and_cache:
     steps:
+      - run:
+      name: Force Git to use HTTPS instead of SSH
+      command: git config --global url."https://github.com/".insteadOf "git@github.com:"
       - checkout
       - restore_cache: # special step to restore the dependency cache
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ commands:
   checkout_and_cache:
     steps:
       - run:
-      name: Force Git to use HTTPS instead of SSH
-      command: git config --global url."https://github.com/".insteadOf "git@github.com:"
+          name: Force Git to use HTTPS instead of SSH
+          command: git config --global url."https://github.com/".insteadOf "git@github.com:"
       - checkout
       - restore_cache: # special step to restore the dependency cache
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/


### PR DESCRIPTION
This PR changes the CircleCI config so that it uses https instead of SSH for the checkout process. Since this is a public repo, there's no need to use SSH for this purpose.