### PR TITLE
[Release] 7.0.0 - Change main font to Source Sans 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ Excerpt from **tokens.scss**:
 
 ```scss
 @mixin fi-text-heading1 {
-  font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial',
-    sans-serif;
+  font-family: 'Source Sans 3', 'Helvetica Neue', 'Arial', sans-serif;
   font-size: 40px;
   line-height: 48px;
   font-weight: 300;
@@ -270,13 +269,13 @@ Excerpt from **suomifiDesignTokens** object:
 exports.suomifiDesignTokens = {
   typography: {
     heading1:
-      "font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', sans-serif; font-size: 40px; line-height: 48px; font-weight: 300;"
+      "font-family: 'Source Sans 3', 'Helvetica Neue', 'Arial', sans-serif; font-size: 40px; line-height: 48px; font-weight: 300;"
   },
   values: {
     typography: {
       heading1: {
         fontFamily:
-          "'Source Sans Pro', 'Helvetica Neue', 'Arial', sans-serif",
+          "'Source Sans 3', 'Helvetica Neue', 'Arial', sans-serif",
         fontSize: { value: 40, unit: 'px' },
         lineHeight: { value: 48, unit: 'px' },
         fontWeight: 300

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-design-tokens",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Design tokens for Suomifi design system",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/tokens.json
+++ b/src/tokens.json
@@ -412,12 +412,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 18,
@@ -436,12 +431,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 18,
@@ -460,12 +450,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -484,12 +469,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -508,12 +488,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -532,12 +507,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -556,12 +526,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -580,12 +545,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -604,12 +564,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 22,
@@ -628,12 +583,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 20,
@@ -652,12 +602,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 40,
@@ -676,12 +621,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 32,
@@ -700,12 +640,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 40,
@@ -724,12 +659,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 32,
@@ -748,12 +678,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 28,
@@ -772,12 +697,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 26,
@@ -796,12 +716,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 22,
@@ -820,12 +735,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 20,
@@ -844,12 +754,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 18,
@@ -868,12 +773,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -892,12 +792,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -916,12 +811,7 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": [
-          "Source Sans 3",
-          "Source Sans 3",
-          "Helvetica Neue",
-          "Arial"
-        ],
+        "fontFamily": ["Source Sans 3", "Helvetica Neue", "Arial"],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,

--- a/src/tokens.json
+++ b/src/tokens.json
@@ -412,7 +412,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 18,
@@ -431,7 +436,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 18,
@@ -450,7 +460,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -469,7 +484,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -488,7 +508,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -507,7 +532,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -526,7 +556,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -545,7 +580,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -564,7 +604,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 22,
@@ -583,7 +628,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 20,
@@ -602,7 +652,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 40,
@@ -621,7 +676,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 32,
@@ -640,7 +700,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 40,
@@ -659,7 +724,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 32,
@@ -678,7 +748,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 28,
@@ -697,7 +772,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 26,
@@ -716,7 +796,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 22,
@@ -735,7 +820,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 20,
@@ -754,7 +844,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 18,
@@ -773,7 +868,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -792,7 +892,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,
@@ -811,7 +916,12 @@
       "category": "typography",
       "version": "1.0",
       "value": {
-        "fontFamily": ["Source Sans Pro", "Helvetica Neue", "Arial"],
+        "fontFamily": [
+          "Source Sans 3",
+          "Source Sans 3",
+          "Helvetica Neue",
+          "Arial"
+        ],
         "genericFontFamily": "sans-serif",
         "fontSize": {
           "value": 16,


### PR DESCRIPTION
This PR updates the typography tokens to use Source Sans 3 instead of the old Source Sans Pro. It also changes the version number to 7.0.0 for the package release.

## Release notes:
**Breaking change:** Change typography tokens to use Source Sans 3 instead of Source Sans Pro.